### PR TITLE
fix(metrics): route calculate_factuality parse through JSONHandler (ACC no longer collapses to 0.25·cosine under gpt-4o-mini)

### DIFF
--- a/Evaluation/metrics/answer_accuracy.py
+++ b/Evaluation/metrics/answer_accuracy.py
@@ -221,7 +221,8 @@ async def calculate_factuality(
     response = await llm.ainvoke(prompt, config={"callbacks": callbacks})
     
     try:
-        classification = ClassificationWithReason(**json.loads(response.content))
+        parsed = await JSONHandler().parse_with_fallbacks(response.content)
+        classification = ClassificationWithReason(**parsed)
         tp = len(classification.TP)
         fp = len(classification.FP)
         fn = len(classification.FN)


### PR DESCRIPTION
## Bug

`Evaluation/metrics/answer_accuracy.py::calculate_factuality` parses the classifier reply with bare `json.loads(response.content)` inside `try/except: return 0.0`. The default judge (gpt-4o-mini, `temperature=0`, no JSON mode — as `generation_eval.py` builds it) returns the JSON wrapped as `Output: {...}\n\nReasoning: ...`, so `json.loads` raises `JSONDecodeError` and factuality silently returns `0.0` for **every** sample. `ACC = 0.75·factuality + 0.25·cosine` therefore degenerates to `0.25·cosine` and cannot separate correct from incorrect answers.

This is the only LLM-parse site in the metrics not using `JSONHandler.parse_with_fallbacks` — `generate_statements` (same file), `coverage.py`, and `faithfulness.py` all route through it and are unaffected.

## Fix

Route the factuality parse through the same handler (already imported at the top of the file):

```python
parsed = await JSONHandler().parse_with_fallbacks(response.content)
classification = ClassificationWithReason(**parsed)
```

## Verification

`compute_answer_correctness` on a perfect-match pair, with the repo's own config (gpt-4o-mini + `BAAI/bge-large-en-v1.5`, CPU):

```python
compute_answer_correctness(
    "What did the cat do?",
    "The cat sat on the mat.",
    "The cat sat on the mat.",   # answer == ground_truth
)
```

| | ACC (perfect match, expected ~1.0) |
|---|---|
| before (`json.loads`) | **0.25** |
| after (`parse_with_fallbacks`) | **1.00** |
